### PR TITLE
feat(CalenderApp,Setting):完成设置页面的编写

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.7",
+    "store2": "^2.14.4",
     "tailwindcss": "^4.1.7",
     "vue": "^3.5.13",
     "vue-router": "^4.5.1"

--- a/src/components/CalendarApp.vue
+++ b/src/components/CalendarApp.vue
@@ -293,7 +293,13 @@ const dayViewTitle = computed(() => {
  */
 const calendarDays = computed(() => {
   // 月视图的日期格子数据
-  const days = []; // 初始化一个空数组，用于存储月视图的每一天的数据
+  const days: {
+    date: Date;
+    dayNumber: number;
+    isCurrentMonth: boolean;
+    isToday: boolean;
+    isWeekend: boolean;
+  }[] = []; // 初始化一个空数组，用于存储月视图的每一天的数据
   const monthStart = new Date(
     currentDate.value.getFullYear(), // 当前年份
     currentDate.value.getMonth(), // 当前月份 (0-11)
@@ -340,7 +346,13 @@ const calendarDays = computed(() => {
  */
 const miniCalendarDays = computed(() => {
   // 迷你日历的日期格子数据
-  const days = [];
+  const days: {
+    date: Date;
+    dayNumber: number;
+    isCurrentMonth: boolean;
+    isToday: boolean;
+    isSelected: boolean;
+  }[] = []; // 初始化一个空数组，用于存储迷你日历的每一天的数据
   const monthStart = new Date(
     miniCalendarDate.value.getFullYear(),
     miniCalendarDate.value.getMonth(),
@@ -381,7 +393,13 @@ const miniCalendarDays = computed(() => {
  */
 const weekViewDays = computed(() => {
   // 周视图的日期数据
-  const days = [];
+  const days: {
+    date: Date;
+    dayName: string;
+    dayNumber: number;
+    isToday: boolean;
+    events: any[];
+  }[] = []; // 初始化一个空数组，用于存储周视图的每一天的数据
   const startOfWeek = getStartOfWeek(currentDate.value);
   const today = new Date();
   today.setHours(0, 0, 0, 0);

--- a/src/components/Setting.vue
+++ b/src/components/Setting.vue
@@ -414,7 +414,7 @@
   @section: 变量与响应式数据
   说明：定义所有设置项的响应式变量，并统一收集到 settings 对象，便于保存和读取。
 */
-import { ref, computed } from "vue";
+import { ref, computed, onMounted } from "vue";
 
 const themeMode = ref("light"); // 主题模式（亮/暗）
 const fontSize = ref("medium"); // 字号
@@ -446,6 +446,34 @@ const settings = computed(() => ({
   weekStart: weekStart.value,
   language: language.value,
 }));
+
+/*
+  @section: 打开设置界面时读取已保存的设置
+  说明：组件挂载后读取 localStorage 中的设置项，如果存在则填充到表单中。
+*/
+onMounted(() => {
+  const saved = localStorage.getItem("settings");
+  if (saved) {
+    try {
+      const obj = JSON.parse(saved);
+      if (obj.themeMode) themeMode.value = obj.themeMode;
+      if (obj.fontSize) fontSize.value = obj.fontSize;
+      if (obj.iconStyle) iconStyle.value = obj.iconStyle;
+      if (typeof obj.notifications === "boolean")
+        notifications.value = obj.notifications;
+      if (typeof obj.notificationSound === "boolean")
+        notificationSound.value = obj.notificationSound;
+      if (typeof obj.soundEffect === "boolean")
+        soundEffect.value = obj.soundEffect;
+      if (typeof obj.hour24 === "boolean") hour24.value = obj.hour24;
+      if (typeof obj.showLunar === "boolean") showLunar.value = obj.showLunar;
+      if (obj.weekStart !== undefined) weekStart.value = obj.weekStart;
+      if (obj.language) language.value = obj.language;
+    } catch (e) {
+      // 解析失败忽略
+    }
+  }
+});
 
 /*
   @section: 保存设置方法


### PR DESCRIPTION
- 编写设置页面；
- 设定了一些基础的条目；
- 可通过点击遮罩层退出设置页面；
- 将所有设置项同一收集到settings对象，便于保存和读取；
- 点击“保存设置”后，弹出设置已保存弹窗并退出设置界面；
- 添加了圆角、阴影、滚动条等组件样式；
- 在打开设置界面时先读取yyi已保存的设置，用已有的设置替换默认选项