### PR TITLE
fix(TodoList): 修复无法改变待办事项字号的问题

### DIFF
--- a/src/components/CalendarHeader.vue
+++ b/src/components/CalendarHeader.vue
@@ -392,15 +392,15 @@ function sendEventNotification(event: any, type: string) {
   if (targetTime && !isNaN(targetTime.getTime())) {
     const diff = Math.round((targetTime.getTime() - now.getTime()) / 60000);
     if (diff > 0) {
-      timeInfo = `（还有${diff}分钟）`;
+      timeInfo = `还有${diff}分钟`;
     }
   }
 
   let body = "";
   if (type === "即将开始") {
-    body = `日程${type}${event.title}：${timeInfo}开始`;
+    body = `${timeInfo}开始`;
   } else {
-    body = `日程${type}${event.title}：${timeInfo}结束`;
+    body = `${timeInfo}结束`;
   }
 
   // 通过 Electron API 发送通知

--- a/src/components/main/ToDoList.vue
+++ b/src/components/main/ToDoList.vue
@@ -67,7 +67,7 @@
 
                   <!-- 标题 -->
                   <div
-                    class="font-medium text-base truncate max-w-[200px] sm:max-w-[300px]"
+                    class="font-medium truncate max-w-[200px] sm:max-w-[300px]"
                     :class="{ 'line-through text-gray-500': todo.completed }"
                   >
                     {{ todo.title }}
@@ -108,7 +108,7 @@
               <!-- 右侧操作区：截止时间单独渲染，删除按钮单独渲染 -->
               <div
                 v-if="todo.end && new Date(todo.end).getFullYear() > 1970"
-                class="text-sm flex items-center gap-1 mr-4"
+                class="flex items-center gap-1 mr-4"
               >
                 <i class="far fa-clock text-xs flex-shrink-0"></i>
                 <span


### PR DESCRIPTION
这个 PR 主要包括以下两个内容。

### 一、修复 todo 事项字号

解释：在原来的代码中，root 字号样式被 text-base 样式覆盖。

现在效果：
（1）小号
![todo小号](https://github.com/user-attachments/assets/b79a9521-e405-4438-9f89-1c441313ca9f)

（2）中号
![todo中号](https://github.com/user-attachments/assets/339c6e9e-0a73-40bf-9e74-d23348e91745)

（3）大号
![todo大号](https://github.com/user-attachments/assets/ecfe6a72-428b-487c-8e0e-e1281285a562)

### 二、调整通知内容

原来会有重复信息：
![屏幕截图 2025-06-05 172623](https://github.com/user-attachments/assets/90e12928-a6e1-4f04-a9ee-589643fa06a1)

现在的效果：
![屏幕截图 2025-06-05 231240](https://github.com/user-attachments/assets/5ae30af1-b8b2-42d4-909b-6dd11cfde48b)
