### PR TITLE
Fix/shortcut dark mode liaohr

### DIFF
--- a/src/renderer/components/CalendarHeader.vue
+++ b/src/renderer/components/CalendarHeader.vue
@@ -743,6 +743,16 @@ const handleGlobalKeydown = (event: KeyboardEvent) => {
         uiStore.toggleHelpModal();
         event.preventDefault();
         break;
+      case "t":
+        // 跳转到今天
+        uiStore.goToToday();
+        event.preventDefault();
+        break;
+      case "d":
+        // 切换到黑暗模式
+        handleThemeToggle();
+        event.preventDefault();
+        break;
     }
   }
 };

--- a/src/renderer/components/CalendarHeader.vue
+++ b/src/renderer/components/CalendarHeader.vue
@@ -860,7 +860,6 @@ watch(isCogHovered, (hovered) => {
   font-size: var(--small-text-font-size);
   background-color: var(--bg-secondary);
   border-color: var(--border-color);
-  transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
 }
 
 .search-box .mode-indicator,

--- a/src/renderer/components/pages/HelpPage.vue
+++ b/src/renderer/components/pages/HelpPage.vue
@@ -43,27 +43,31 @@
         <!-- 导航快捷键部分 -->
         <div class="shortcut-section mb-6">
           <h4 class="text-md font-semibold mb-3 text-gray-700 border-b pb-1">
-            Navigation
+        Navigation
           </h4>
           <div class="grid grid-cols-1 gap-3">
-            <div class="shortcut-item flex justify-between items-center">
-              <span class="key-combo"><kbd>h</kbd> or <kbd>←</kbd></span>
-              <span class="description text-gray-700"
-                >Previous (week/month)</span
-              >
-            </div>
-            <div class="shortcut-item flex justify-between items-center">
-              <span class="key-combo"><kbd>l</kbd> or <kbd>→</kbd></span>
-              <span class="description text-gray-700">Next (week/month)</span>
-            </div>
-            <div class="shortcut-item flex justify-between items-center">
-              <span class="key-combo"><kbd>j</kbd> or <kbd>↓</kbd></span>
-              <span class="description text-gray-700">Scroll down</span>
-            </div>
-            <div class="shortcut-item flex justify-between items-center">
-              <span class="key-combo"><kbd>k</kbd> or <kbd>↑</kbd></span>
-              <span class="description text-gray-700">Scroll up</span>
-            </div>
+        <div class="shortcut-item flex justify-between items-center">
+          <span class="key-combo"><kbd>h</kbd> or <kbd>←</kbd></span>
+          <span class="description text-gray-700"
+            >Previous (week/month)</span
+          >
+        </div>
+        <div class="shortcut-item flex justify-between items-center">
+          <span class="key-combo"><kbd>l</kbd> or <kbd>→</kbd></span>
+          <span class="description text-gray-700">Next (week/month)</span>
+        </div>
+        <div class="shortcut-item flex justify-between items-center">
+          <span class="key-combo"><kbd>j</kbd> or <kbd>↓</kbd></span>
+          <span class="description text-gray-700">Scroll down</span>
+        </div>
+        <div class="shortcut-item flex justify-between items-center">
+          <span class="key-combo"><kbd>k</kbd> or <kbd>↑</kbd></span>
+          <span class="description text-gray-700">Scroll up</span>
+        </div>
+        <div class="shortcut-item flex justify-between items-center">
+          <span class="key-combo"><kbd>t</kbd></span>
+          <span class="description text-gray-700">Jump to today</span>
+        </div>
           </div>
         </div>
 
@@ -166,6 +170,10 @@
             <div class="shortcut-item flex justify-between items-center">
               <span class="key-combo"><kbd>?</kbd></span>
               <span class="description text-gray-700">Show This Help</span>
+            </div>
+            <div class="shortcut-item flex justify-between items-center">
+              <span class="key-combo"><kbd>d</kbd></span>
+              <span class="description text-gray-700">Toggle Dark Mode</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
This pull request introduces new keyboard shortcuts for improved user interaction and updates the help page to document these shortcuts. The most important changes include adding shortcuts for jumping to today's date and toggling dark mode, along with corresponding updates to the help page.

### New Keyboard Shortcuts

* [`src/renderer/components/CalendarHeader.vue`](diffhunk://#diff-bc39a754649dcb8cccdc6aa8730f10314a6a539be1e0445ce8526689de4d138aR746-R755): Added handling for the "t" key to jump to today's date and the "d" key to toggle dark mode in the `handleGlobalKeydown` function.

### Help Page Updates

* [`src/renderer/components/pages/HelpPage.vue`](diffhunk://#diff-31f0f76f325739e4e1e7aaa3787a972727426242c341b5ff6233c378f08ac3bbR66-R69): Documented the "t" key shortcut for jumping to today's date.
* [`src/renderer/components/pages/HelpPage.vue`](diffhunk://#diff-31f0f76f325739e4e1e7aaa3787a972727426242c341b5ff6233c378f08ac3bbR174-R177): Documented the "d" key shortcut for toggling dark mode.